### PR TITLE
Make the build valid ES Modules

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -35,6 +35,28 @@ function run( cmd, args )
 	execFileSync( cmd, args, { stdio: 'inherit', cwd: root } );
 }
 
+// Emscripten's Node support code (-sENVIRONMENT=...,node) loads node builtins
+// with require() via a createRequire shim. That's valid ESM at runtime, but
+// bundlers flag the require() calls when the file is consumed as an ES module.
+// The calls all sit at the top level of the async MODULARIZE factory, so
+// rewrite them to dynamic imports (node builtins expose everything as named
+// exports, so namespace access keeps working) and drop the dead shim.
+function rewriteRequires( file )
+{
+	const path = join( root, file );
+	let src = readFileSync( path, 'utf8' );
+	src = src.replaceAll( /\brequire\(\s*["']([^"']+)["']\s*\)/g, '(await import("$1"))' );
+	// node: scheme on every builtin import (emscripten emits some itself, bare)
+	// so bundlers unambiguously treat them as Node builtins.
+	src = src.replaceAll( /\bimport\(\s*["'](?:node:)?(fs|path|url|util|module|crypto|worker_threads)["']\s*\)/g, 'import("node:$1")' );
+	src = src.replace( /const\s*{\s*createRequire\s*}\s*=\s*await import\(\s*["'](?:node:)?module["']\s*\);?\s*(?:\/\*\*[^]*?\*\/\s*)?var require\s*=\s*createRequire\(\s*import\.meta\.url\s*\);?/, '' );
+	if ( /\brequire\s*\(\s*["']/.test( src ) || src.includes( 'createRequire(import.meta.url)' ) )
+	{
+		throw new Error( `${file}: require() still present after rewrite — did emscripten's output change?` );
+	}
+	writeFileSync( path, src );
+}
+
 function findFile( dir, name )
 {
 	for ( const e of readdirSync( dir, { withFileTypes: true } ) )
@@ -117,6 +139,7 @@ const mtFlags = [
 // --- single-threaded ---
 // Separate-wasm build (also emits the shared TypeScript defs).
 run( 'em++', [ 'src/bindings.cpp', stLib, ...commonFlags, '--emit-tsd', 'box3d.d.ts', '-o', 'dist/box3d.mjs' ] );
+rewriteRequires( 'dist/box3d.mjs' );
 
 // emscripten hardcodes MainModule / MainModuleFactory in --emit-tsd output.
 // Rename them to friendlier box3d names.
@@ -263,12 +286,15 @@ writeFileSync( tsdPath, tsd );
 
 // Inlined single-file build (wasm base64-embedded).
 run( 'em++', [ 'src/bindings.cpp', stLib, ...commonFlags, '-sSINGLE_FILE=1', '-o', 'dist/box3d.inline.mjs' ] );
+rewriteRequires( 'dist/box3d.inline.mjs' );
 
 // --- multithreaded (pthreads) ---
 run( 'em++', [ 'src/bindings.cpp', mtLib, ...commonFlags, ...mtFlags, '-o', 'dist/box3d.mt.mjs' ] );
+rewriteRequires( 'dist/box3d.mt.mjs' );
 // Single-file MT build: base64-embedding the wasm sidesteps the SharedArrayBuffer
 // + separate-wasm-fetch friction (as JoltPhysics.js does).
 run( 'em++', [ 'src/bindings.cpp', mtLib, ...commonFlags, ...mtFlags, '-sSINGLE_FILE=1', '-o', 'dist/box3d.mt.inline.mjs' ] );
+rewriteRequires( 'dist/box3d.mt.inline.mjs' );
 
 console.log( '\nBuild artifacts:' );
 for ( const f of [

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -35,16 +35,31 @@ function run( cmd, args )
 	execFileSync( cmd, args, { stdio: 'inherit', cwd: root } );
 }
 
-// Emscripten's Node support code (-sENVIRONMENT=...,node) loads node builtins
-// with require() via a createRequire shim. That's valid ESM at runtime, but
-// bundlers flag the require() calls when the file is consumed as an ES module.
-// The calls all sit at the top level of the async MODULARIZE factory, so
-// rewrite them to dynamic imports (node builtins expose everything as named
-// exports, so namespace access keeps working) and drop the dead shim.
-function rewriteRequires( file )
+// Post-process an emitted module into clean, valid ESM:
+//
+// 1. Emscripten's Node support code (-sENVIRONMENT=...,node) loads node
+//    builtins with require() via a createRequire shim. That's valid ESM at
+//    runtime, but bundlers flag the require() calls when the file is consumed
+//    as an ES module. The calls all sit at the top level of the async
+//    MODULARIZE factory, so rewrite them to await import (node builtins expose
+//    everything as named exports, so namespace access keeps working) and drop
+//    the dead shim.
+//
+// 2. SINGLE_FILE builds (*.inline.mjs) embed the wasm, so emscripten's file
+//    readers (readAsync / readBinary, the node:fs / node:path / node:url
+//    imports) are dead code. Strip them so the inline builds carry no node builtin
+//    references and bundle with no config.
+//
+// -sSOURCE_PHASE_IMPORTS would obsolete most of this post-processing: the wasm
+// loads via a static `import source` instead of fetch/fs, leaving only the MT
+// worker_threads import to rewrite. Adopt it once browsers, bundlers, and
+// emscripten's optimizer all support the syntax.
+function validateESModule( file )
 {
 	const path = join( root, file );
 	let src = readFileSync( path, 'utf8' );
+
+	// require() -> await import
 	src = src.replaceAll( /\brequire\(\s*["']([^"']+)["']\s*\)/g, '(await import("$1"))' );
 	// node: scheme on every builtin import (emscripten emits some itself, bare)
 	// so bundlers unambiguously treat them as Node builtins.
@@ -54,6 +69,27 @@ function rewriteRequires( file )
 	{
 		throw new Error( `${file}: require() still present after rewrite — did emscripten's output change?` );
 	}
+
+	// dead file readers (SINGLE_FILE builds only)
+	if ( file.includes( '.inline.' ) )
+	{
+		// arrow function with at most one nested brace level, which covers all
+		// of emscripten's reader closures
+		const arrow = /(?:async\s*)?(?:\([^()]*\)|[\w$]+)\s*=>\s*\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}/.source;
+		src = src.replaceAll( new RegExp( `\\b(?:readAsync|readBinary)=${arrow};?`, 'g' ), '' );
+		src = src.replace( 'var readAsync,readBinary;', '' );
+		src = src.replace( /var fs=\(await import\("node:fs"\)\);?/, '' );
+		// Node-only scriptDirectory computation, the sole user of node:path/node:url
+		src = src.replace( /if\(_scriptName\.startsWith\("file:"\)\)\{scriptDirectory=[^{}]*\}/, '' );
+		for ( const leftover of [ 'readAsync', 'readBinary', 'readFileSync', 'node:fs', 'node:path', 'node:url' ] )
+		{
+			if ( src.includes( leftover ) )
+			{
+				throw new Error( `${file}: ${leftover} still present after strip — did emscripten's output change?` );
+			}
+		}
+	}
+
 	writeFileSync( path, src );
 }
 
@@ -139,7 +175,7 @@ const mtFlags = [
 // --- single-threaded ---
 // Separate-wasm build (also emits the shared TypeScript defs).
 run( 'em++', [ 'src/bindings.cpp', stLib, ...commonFlags, '--emit-tsd', 'box3d.d.ts', '-o', 'dist/box3d.mjs' ] );
-rewriteRequires( 'dist/box3d.mjs' );
+validateESModule( 'dist/box3d.mjs' );
 
 // emscripten hardcodes MainModule / MainModuleFactory in --emit-tsd output.
 // Rename them to friendlier box3d names.
@@ -286,15 +322,15 @@ writeFileSync( tsdPath, tsd );
 
 // Inlined single-file build (wasm base64-embedded).
 run( 'em++', [ 'src/bindings.cpp', stLib, ...commonFlags, '-sSINGLE_FILE=1', '-o', 'dist/box3d.inline.mjs' ] );
-rewriteRequires( 'dist/box3d.inline.mjs' );
+validateESModule( 'dist/box3d.inline.mjs' );
 
 // --- multithreaded (pthreads) ---
 run( 'em++', [ 'src/bindings.cpp', mtLib, ...commonFlags, ...mtFlags, '-o', 'dist/box3d.mt.mjs' ] );
-rewriteRequires( 'dist/box3d.mt.mjs' );
+validateESModule( 'dist/box3d.mt.mjs' );
 // Single-file MT build: base64-embedding the wasm sidesteps the SharedArrayBuffer
 // + separate-wasm-fetch friction (as JoltPhysics.js does).
 run( 'em++', [ 'src/bindings.cpp', mtLib, ...commonFlags, ...mtFlags, '-sSINGLE_FILE=1', '-o', 'dist/box3d.mt.inline.mjs' ] );
-rewriteRequires( 'dist/box3d.mt.inline.mjs' );
+validateESModule( 'dist/box3d.mt.inline.mjs' );
 
 console.log( '\nBuild artifacts:' );
 for ( const f of [


### PR DESCRIPTION
Since this library ships as an ES module, some parsers (like https://esm.sh/ in my experince) may complain with the occurrences of `require()` and `fs.readFileSync()` in the output files.

To fix this we can replace the `require()` with a valid `await import()` and actually get rid of those imports altogether in the inline build, since they're not needed.

Right now the only way I found we could do that is by using string replace, but in the future we should be able to use the `-sSOURCE_PHASE_IMPORTS` emscripten flag which compiles to the new proposal for the [source phase imports](https://github.com/tc39/proposal-source-phase-imports).

Btw, good job overally with the library 🙌